### PR TITLE
fix(class-diagram): self dashed relationの描画を抑制

### DIFF
--- a/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/design.md
+++ b/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/design.md
@@ -3,186 +3,119 @@
 ID: "iss-00042"
 タイトル: "Suppress Self Dependency Relations"
 関連GitHub: ["#42"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-26"
 依存: ["requirement.md"]
 親: ["epic-00039", "init-00038"]
 ---
 
-# iss-00042 Suppress Self Dependency Relations — 設計（どう実現するか）
-
-> このテンプレートは最小 scaffold です。プロジェクトの目的、作業内容、人間の理解しやすさ、エージェントの実行可能性に合わせて、項目は追加・削除・統合・並べ替えてよい。
-
-## 親図（Diagram）参照
-- Epic 図:
-  - ...
-- Initiative 図:
-  - ...
-- 再利用する決定:
-  - ...
+# iss-00042 Suppress Self Dependency Relations — 設計
 
 ## 目的・制約
-- 目的:
-  - ...
-- 必須 / 禁止:
-  - ...
-- 非交渉制約:
-  - ...
-- 前提:
-  - ...
 
-## 既存実装 / 規約の理解
-- 参照した実装 / docs:
-  - ...
-- 現状理解:
-  - ...
-- 採用するパターン:
-  - ...
-- 採用しないもの:
-  - ...
-- 影響範囲:
-  - ...
+`dependency` relation の出力強化後に実プロダクト図で観測された `A ..> A` を、図の可読性を損なう self dashed relation ノイズとして抑制する。
 
-## 採用方針 / トレードオフ
-- 論点:
-  - ...
-- 選択肢:
-  - ...
-- 決定:
-  - ...
+この issue では `dependency` の PlantUML 表記、CLI option、設定 schema、型用途と runtime 用途の細分類は変更しない。pyclassuml の外部 CLI、読み取り専用、AST 静的解析のみという前提も変更しない。
 
-## 依存関係分析
-- module 依存:
-  - ...
-- class 依存（必要時）:
-  - ...
-- function 依存（必要時）:
-  - ...
-- file 依存:
-  - ...
-- 上流 / 前提:
-  - ...
-- 下流 / 依存先:
-  - ...
-- 実装起点:
-  - 依存の少ないもの / 先に固定すべき interface / 先に通すべき test を書く
-- 順序への影響:
-  - plan では upstream / prerequisite から順に step を組む
+## 既存実装の理解
 
-## モジュール依存図（Module Dependency Diagram）
-- タイトル:
-  - ...
-- 答える問い:
-  - どの module / class / file / function の依存方向を固定し、どこから実装を始めるか
-- 範囲:
-  - ...
-- 含めない詳細:
-  - 網羅的な call graph / 全 method / 全 import は描かない
-- 更新条件:
-  - 依存方向、責務境界、実装起点、変更対象 module が変わるとき
-- 図:
-  - 下の `plantuml` block を更新する
+- `select_classes_and_relations()` が parse / traversal 結果から `SelectedRelation` 候補を集める。
+- `direct_class_call`、`direct_class_member_access`、`type_check_dependency`、`cast_dependency`、`local_annotation_dependency` は `dependency` relation 候補として扱われる。
+- `_normalize_relations()` は同一 triple の evidence 優先度と同一 endpoint の relation 種別優先度を決め、最終的な `SelectedRelations` を返す。
+- `generate` と `diff` は共通の selection 結果を描画するため、selection 層で suppression すれば両コマンドへ同じ policy が適用される。
+- `src/pyclassuml/render/document.py` は `dependency` を `..>` として描画するだけであり、今回の意味論を render 層へ移す必要はない。
 
-### 図表（UML / 原則: モジュール依存 / パッケージ依存差分）
+## 採用方針
+
+`_normalize_relations()` の入口で、`relation_type in {"dependency", "uses"}` かつ `source_class_id == target_class_id` の候補を除外する。
+
+この位置を採用する理由:
+
+- parse 層の reference 抽出仕様を複雑化しない。
+- render 直前の見た目だけの除外ではなく、selection 結果と render 入力の relation 集合を一致させられる。
+- `generate` / `diff` の共通経路に適用できる。
+- 既存の non-self dependency / uses、association、composition、aggregation、inherits、realizes の semantics を変更しない。
+
+採用しない案:
+
+- render 層で `A ..> A` の行だけ捨てる案は、analysis 結果と描画結果の不一致を生みやすいため採用しない。
+- classmethod return、annotation、factory call など原因別に parse 層で抑える案は、仕様と実装の分岐が増えるため採用しない。
+- type-only / runtime dependency の分類はこの issue の対象外とする。
+
+## モジュール依存図
+
 ```plantuml
 @startuml
 top to bottom direction
-' show module / class / file / function dependencies that affect implementation order
-' do not copy Initiative/Epic diagrams
 
-rectangle "対象module-a" as A
-rectangle "対象module-b" as B
-A --> B : depends_on
+rectangle "parse\nParsedModule / ClassReference" as Parse
+rectangle "analyze.selection\nSelectedRelation candidates\n_normalize_relations()" as Selection
+rectangle "render.document\nPlantUML relation lines" as Render
+rectangle "cli app\ngenerate / diff" as App
+
+Parse --> Selection : class references
+Selection --> Render : SelectedRelations\nself dependency suppressed
+Render --> App : .puml output
 @enduml
 ```
 
-## ローカル図の差分（Local Diagram Delta / 必要時）
-- 変更する境界 / 責務 / 相互作用:
-  - N/A: 理由
-
 ## インターフェース契約
-- API / function / protocol / data boundary:
-  - ...
 
-## シーケンス差分（Sequence Delta / 必要時）
-- 変更する相互作用:
-  - N/A: 理由
-- retry / transaction / external API / queue:
-  - ...
-- UML:
-  - N/A: 理由
-
-## ドメインモデル差分（Domain Model Delta / 必要時）
-- 親 model 参照:
-  - ...
-- aggregate / entity / value object 変更:
-  - N/A: 理由
-- domain event / policy / specification 変更:
-  - ...
-- 不変条件の変更:
-  - ...
-- UML:
-  - N/A: 理由
-
-## クラス / インターフェース詳細設計（必要時）
-- Class / Interface:
-  - ...
-- 責務:
-  - ...
-- 連携:
-  - ...
-- UML:
-  - N/A: 理由
+- public CLI:
+  - 変更しない。
+- model contract:
+  - `SelectedRelation` の型や relation type enum 相当の値は変更しない。
+- selection contract:
+  - `dependency` / `uses` の self relation は `SelectedRelations.relations` に含めない。
+  - non-self dependency / uses は従来通り endpoint / evidence 優先度に従って残す。
+- diagnostics:
+  - self dependency suppression は正常なノイズ除去として扱い、新規 warning / error は出さない。
 
 ## ディレクトリ / ファイル変更計画
+
 ```text
 .
 |-- src/
-|   |-- package/
-|   |   |-- new_module.py        # 追加: 目的; 依存: ...
-|   |   |-- existing_module.py   # 変更: 目的; 依存: ...
-|   |   `-- renamed_module.py    # 移動/rename 元: src/package/old_module.py; 目的
-|   `-- tests/
-|       `-- test_new_module.py   # 追加/変更: 目的; 依存: src/package/new_module.py
-|-- docs/
-|   `-- reference.md             # 読取のみ: 目的
-`-- legacy/
-    `-- obsolete_file.py         # 削除: 目的; 依存: 代替準備完了
+|   `-- pyclassuml/
+|       `-- analyze/
+|           `-- selection.py            # 変更: self dashed relation を正規化時に除外
+`-- tests/
+    |-- analyze/
+    |   `-- test_selection.py           # 変更: self dependency suppression と non-self 維持を確認
+    `-- app/
+        |-- test_generate.py            # 変更: generate 出力で self dependency が出ないことを確認
+        `-- test_diff.py                # 変更: diff 出力で同じ policy が適用されることを確認
 ```
 
 ## 要件 → 設計マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+
+- AC-001:
+  - `_normalize_relations()` で `dependency` / `uses` self relation を除外する。
+- AC-002:
+  - 除外条件を `dependency` かつ `source == target` に限定し、non-self dependency tests を維持・追加する。
+- AC-003:
+  - selection 層で policy を適用し、app-level の `generate` / `diff` tests で `.puml` 出力を確認する。
+- EC-001:
+  - `dependency` / `uses` 以外の relation は今回の新規仕様化対象外とし、除外条件に含めない。
+- EC-002:
+  - evidence kind の分類は変更せず、self endpoint だけで判定する。
 
 ## テスト戦略
+
 - 単体:
-  - ...
-- 統合:
-  - ...
-- E2E / manual:
-  - ...
-- migration / rollback / feature flag if needed:
-  - ...
+  - `tests/analyze/test_selection.py` に、同一 class 参照が `SelectedRelations` に残らないことと、同じ fixture 内の non-self dependency が残ることを確認する test を追加する。
+- アプリケーション:
+  - `tests/app/test_generate.py` で generate の `.puml` relation lines を確認する。
+  - `tests/app/test_diff.py` で diff の `.puml` relation lines を確認する。
+- 手動:
+  - 今回は自動 test で generate / diff の policy を閉じるため、追加の手動 PlantUML 確認は必須にしない。
 
-## 要件 / 例外 -> 検証マッピング
-- AC-001 -> ...
-- EC-001 -> ...
-- constraint -> ...
+## リスク
 
-## リスク / 移行 / ロールバック（必要時）
-- ...
+- 自己 factory や recursive な設計意図を dependency として見たい利用者には情報が減る可能性がある。
+- ただし class diagram の構造理解では `A ..> A` が読者に与える追加情報は小さく、今回の目的では可読性改善を優先する。
 
 ## 未確定事項
-- Q-001:
-  - 質問:
-  - 選択肢:
-    - A:
-      - ...
-    - B:
-      - ...
-  - 推奨案:
-    - ...
-  - 影響範囲:
-    - ...
+
+なし。

--- a/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/plan.md
+++ b/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/plan.md
@@ -3,267 +3,237 @@
 ID: "iss-00042"
 タイトル: "Suppress Self Dependency Relations"
 関連GitHub: ["#42"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-26"
 依存: ["requirement.md", "design.md"]
 親: ["epic-00039", "init-00038"]
 ---
 
-# iss-00042 Suppress Self Dependency Relations — 実装計画（実行契約 / Execution Contract）
-
-> このテンプレートは最小 scaffold です。`plan.md` は計画済み契約（planned contract）を所有し、実装者が step を上から順に実行できる command queue として書く。実行結果、逸脱、発見された tests、reviewer verdict、commit/no-op evidence は `report.md` の観測証跡台帳（observed evidence ledger）に記録する。実行 policy は `workflow_issue.md`、Issue 計画の書き方は `phase_plan_issue.md` と `docs/authoring/issue-plan.md` を正本にする。
+# iss-00042 Suppress Self Dependency Relations — 実装計画
 
 ## この計画で満たす要件ID
-- AC:
-  - ...
-- EC:
-  - ...
-- 制約:
-  - ...
+
+- AC-001: self dependency を描画しない
+- AC-002: 異なるクラス間の dependency は維持する
+- AC-003: relation policy は generate / diff で一致する
+- EC-001: 他 relation が同じ endpoint にある場合
+- EC-002: type-only / runtime の混在
 
 ## 依存関係から導く実装順序
-- 依存関係の正本:
-  - `design.md` の依存関係、図、ファイル変更計画
-- 順序ルール:
-  - prerequisite / lower-dependency slice から先に閉じる
-  - downstream slice は前提が固定されてから置く
-- step 依存サマリー:
-  - S01:
-    - 依存:
-    - unblock:
-    - 対象ファイル:
+
+- S01:
+  - 依存: `design.md` の selection 層方針
+  - unblock: app-level generate / diff consistency tests
+  - 対象: `src/pyclassuml/analyze/selection.py`, `tests/analyze/test_selection.py`
+- S02:
+  - 依存: S01 の selection contract
+  - unblock: final reviewer / PR delivery
+  - 対象: `tests/app/test_generate.py`, `tests/app/test_diff.py`
+- S90:
+  - 依存: S01 / S02 の実装結果
+  - unblock: final spec review
+  - 対象: README / docs impact inspection
+- S99:
+  - 依存: S01 / S02 / S90
+  - unblock: PR delivery and merge-preparation
+  - 対象: validation, sync, final reviewer gates, commit evidence
 
 ## ステップ一覧
+
 - S01:
-  - 観測可能な振る舞い:
-  - 依存:
-  - unblock:
-  - 対象ファイル:
-  - 閉じる要件:
-  - レビューゲート:
+  - 観測可能な振る舞い: selection 結果に `dependency` self relation が含まれず、non-self dependency は含まれる。
+  - レビューゲート: code-reviewer pass。
 - S02:
-  - ...
+  - 観測可能な振る舞い: generate / diff の `.puml` に self dependency line が出ず、non-self dependency line は出る。
+  - レビューゲート: code-reviewer pass。
+- S90:
+  - 観測可能な振る舞い: public docs 更新の要否が判断され、必要なら反映される。
+  - レビューゲート: spec-reviewer pass。
+- S99:
+  - 観測可能な振る舞い: issue 全体の verification / reviewer / PR delivery evidence が揃う。
+  - レビューゲート: qa-reviewer pass, code-reviewer pass, spec-reviewer pass。
 
-## 要件 ↔ ステップ対応
-- AC-001 -> S01
-- EC-001 -> S02
+## 仕様固定クロージャ索引
 
-## 仕様固定クロージャ索引（Spec-Locked Closure Index）
-
-> これは Issue 全体のテスト一覧ではなく、仕様を縮小解釈・後付けテスト・過剰実装しないための coverage ledger です。実際の step-local obligation と concrete seeds は各 implementation step の `具体テストケース一覧` に置く。
-
-| 識別子（ID） | ステップ（step） | スライス（slice） | 種別（type） | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル（evidence level） | クロージャ証跡（closure evidence） |
+| ID | ステップ | スライス | 種別 | 仕様リンク | 固定する期待値 | 観測可能な入力 / 状態 | 防ぐ bug class | 必須 | 証跡レベル | クロージャ証跡 |
 |---|---|---|---|---|---|---|---|---|---|---|
-| tc-001 | S01 | <behavior> | 受け入れ（acceptance） | AC-001 | ... | ... | 仕様 drift（spec drift） | yes | red-required | ステップ完了証跡（report step closure） |
-| tc-002 | S01 | <behavior> | 否定系（negative） | EC-001 | ... | ... | 沈黙失敗（silent failure） | yes | inspect-only | ステップ完了証跡（report step closure） |
+| tc-s01-001 | S01 | selection | acceptance | AC-001, AC-002, EC-002 | `dependency` / `uses` self relation は除外され、non-self dependency は残る | 同一 class 参照と別 class 参照を含む ParsedModule | self dashed relation ノイズ再発 / non-self dependency 消失 | yes | red-required | report S01 |
+| tc-s02-001 | S02 | generate | acceptance | AC-001, AC-002, AC-003 | generate の `.puml` で `A ..> A` は出ず `A ..> B` は出る | generate fixture | command 別 policy drift | yes | red-required | report S02 |
+| tc-s02-002 | S02 | diff | acceptance | AC-001, AC-002, AC-003 | diff の `.puml` で `A ..> A` は出ず `A ..> B` は出る | diff fixture | command 別 policy drift | yes | red-required | report S02 |
+| tc-s90-001 | S90 | docs impact | inspection | 禁止事項 / scope | README / docs 更新が不要または必要最小限に反映済み | docs inspection | user-facing semantics の説明漏れ | yes | inspect-only | report S90 |
 
-- 証跡レベル（evidence level）:
-  - red-required: 実装前に失敗する新規 test / characterization を固定する。
-  - covered-existing: 既存 test が対象 behavior を検出できる根拠を固定する。
-  - inspect-only: docs / template / config などを inspection、structural assertion、review evidence で閉じる。
-  - manual-required: 自動化できない確認手順、期待結果、記録先を固定する。
-- 詳細化方針:
-  - 件数ではなく、AC、changed contract、failure mode、regression risk、invariant、manual / integration risk から必要な obligation を決める。
-  - private method、実装アルゴリズム、mock 構造、assert 細部は原則固定しない。
+## 実行ルール
 
-## レビュー / QA ゲート方針
-- RG1 step review:
-  - 実施タイミング: 各 implementation step の commit 前
-  - reviewer: code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only）
-  - pass 条件: review_status: pass
-- QG1 final QA:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage、missing high-value tests、manual / integration test 要否
-- SG1 final spec review:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / docs 整合
+- 実装は active issue を正本として進める。
+- runtime code / tests は `dev-coder` へ委任する。委任不可の場合のみ親実装例外を `report.md` に記録する。
+- 各 step は Red evidence、Green evidence、reviewer pass を `report.md` に記録する。
+- material な仕様解釈が発生したら、実装を広げる前に `report.md` の Decision Ledger に統合し、必要なら plan amendment と再レビューを行う。
 
-## 実行ルール（全ステップ共通）
-- 各 implementation step は原則として 1 behavior slice / 1 review scope / 1 commit boundary とする。
-- `plan.md` には planned requirements、evidence destination、closure 条件だけを書く。observed result は `report.md` に書く。
-- docs-only / inspect-only / manual-required step は code test 前提にせず、代替 evidence path と rationale を implementation 前に固定する。
-- implementation 中に新しい仕様、bug class、外部 contract risk、未計画の closure が見つかった場合は、report 記録だけで足りるか、plan amendment と re-review が必要かを判断する。
+## 実装ステップ S01 — selection contract
 
-## 実装ステップ
-
-### 実装ステップ S01 — <観測可能な振る舞い>
-- 振る舞いの目標（behavior goal）:
-  - ...
-- design 参照:
-  - ...
-- 依存:
-  - ...
-- unblock:
-  - ...
-- 対象ファイル:
-  - ...
-- 計画済み契約（planned contract）:
-  - scope:
-    - 実装・文書化する範囲:
-  - テスト義務（test obligation）:
-    - closure id:
-      - tc-001
-    - coverage rationale:
-      - AC / changed contract / failure mode / regression risk / invariant / manual risk から必要性を書く:
-  - Red / 代替証跡の要件:
-    - red-required / covered-existing:
-      - 実装前に確認する failing test、characterization、または既存 test sensitivity:
-    - docs-only / inspect-only / manual-required:
-      - code test を置かない理由:
-      - 代替 evidence path:
-      - manual 手順と期待結果:
-  - 実装範囲（implementation scope）:
-    - allowed paths:
-      - ...
-    - forbidden changes:
-      - ...
-  - Green 検証:
-    - command / inspection / manual evidence:
-      - ...
-  - Refactor / cleanup ガードレール:
-    - 目的:
-    - 禁止する広がり:
-  - closure 証跡要件:
-    - Step Contract Closure:
-    - Test Contract Closure:
-    - Closure Coverage:
-  - report 証跡の記録先:
-    - `report.md` の対象 section / ledger:
-  - amendment trigger（plan amendment が必要になる契機）:
-    - plan amendment と re-review が必要になる発見:
-
-#### 委任契約（delegation contract）
-- 委任ロール（delegated role）:
-  - dev-coder / doc-writer / other named worker / N/A
-- 入力 docs:
+- behavior goal:
+  - `SelectedRelations.relations` に `dependency` / `uses` self relation を含めない。
+  - 同じ入力に含まれる non-self dependency relation は残す。
+- input docs / source of truth:
   - `requirement.md`
   - `design.md`
   - `plan.md`
-  - workflow / authoring docs:
-  - current target files:
+  - `spec-dock/docs/workflow_issue.md`
+- design 参照:
+  - `design.md` の「採用方針」「インターフェース契約」。
+- 対象ファイル:
+  - `src/pyclassuml/analyze/selection.py`
+  - `tests/analyze/test_selection.py`
+- Red:
+  - `uv run pytest tests/analyze/test_selection.py -k self_dependency`
+  - 実装前に新規 test が self dependency の残存で失敗することを確認する。
+- Green:
+  - `uv run pytest tests/analyze/test_selection.py -k "dependency or self_dependency"`
+- forbidden changes:
+  - relation type の追加・変更。
+  - CLI / render 表記の変更。
+  - parse 層の reference 抽出仕様変更。
+- closure:
+  - `tc-s01-001` が pass。
+  - code-reviewer が pass。
+- report evidence destination:
+  - `report.md` の TDD / Red / Green、Step Contract Closure、Test Contract Closure、Delegated Worker Evidence。
+- amendment trigger:
+  - `dependency` / `uses` 以外の self relation 抑制が必要になる場合。
+  - allowed paths 外の変更が必要になる場合。
+  - diagnostics / CLI / render arrow semantics の変更が必要になる場合。
+
+### 具体テストケース S01
+
+- `tc-s01-001`: selection は self dashed relation を除外し non-self dependency を残す。
+  - 前提: `ParsedModule` に `A -> A` の `direct_class_call`、`A -> A` の `local_annotation_dependency`、`A -> A` の `method_return_annotation`、`A -> B` の `direct_class_call` がある。
+  - 操作: `select((seed,), seeds=("pkg/source.py",), reachable=("pkg/source.py",))` を実行する。
+  - 期待結果: `SelectedRelation("pkg/source.py:A", "pkg/source.py:B", "dependency", "direct_class_call")` だけが残り、`A -> A` dependency は残らない。
+  - 失敗検出: production suppression なしでは `A -> A` dependency が relations に残る。
+  - 検証方法: `uv run pytest tests/analyze/test_selection.py -k self_dependency`。
+
+### 委任契約 S01
+
+- delegated role:
+  - dev-coder
+- source of truth:
+  - active issue docs: `requirement.md`, `design.md`, `plan.md`
+- acceptance criteria:
+  - AC-001, AC-002, EC-002
 - 許可 paths:
-  - ...
+  - `src/pyclassuml/analyze/selection.py`
+  - `tests/analyze/test_selection.py`
 - 禁止 changes:
-  - ...
-- 受け入れ条件:
-  - closure id / step close condition:
-- 必須 tests または docs-only verification:
-  - targeted command / inspection / docs diff / manual evidence:
+  - 上記以外の runtime code / docs 変更。
+  - CLI option、設定、render arrow 変更。
+- 必須出力:
+  - 変更ファイル、Red / Green command と結果、material decision の有無。
 - reviewer focus:
-  - code-reviewer（code / runtime / tests / scaffold behavior）; spec-reviewer（docs-only / template-only / skill-text-only docs/spec alignment）
-- 必須出力（output required）:
-  - changed files:
-  - verification result:
-  - report evidence to update:
-  - unresolved risks:
-- 停止条件（stop conditions）:
-  - input docs conflict / path outside allowed scope / verification cannot run / acceptance cannot be met:
+  - code-reviewer: `_normalize_relations()` で `dependency` / `uses` self relation だけが除外され、non-self dashed relation と他 relation type に副作用がないこと。
+- report evidence destination:
+  - `report.md` の Delegated Worker Evidence と S01 closure rows。
+- 停止条件:
+  - 要件と設計の衝突。
+  - allowed paths 以外の変更が必要。
+  - Red / Green を実行できない。
 
-#### 具体テストケース一覧
+## 実装ステップ S02 — generate / diff consistency
 
-> この欄は full test inventory ではありません。step-local obligation と concrete red / characterization / inspect / manual seeds を、実装前に固定するための欄です。
+- behavior goal:
+  - `generate` と `diff` の `.puml` 出力で同じ self dependency suppression policy が観測できる。
+- input docs / source of truth:
+  - `requirement.md`
+  - `design.md`
+  - `plan.md`
+  - `spec-dock/docs/workflow_issue.md`
+- 対象ファイル:
+  - `tests/app/test_generate.py`
+  - `tests/app/test_diff.py`
+- Red:
+  - `uv run pytest tests/app/test_generate.py tests/app/test_diff.py -k self_dependency`
+  - 実装前または S01 実装を一時的に戻した状態で失敗する test sensitivity を確認する。S01 後に追加する場合は、test が実装 contract を直接検出することを inspection で補足する。
+- Green:
+  - `uv run pytest tests/app/test_generate.py tests/app/test_diff.py -k "self_dependency or direct_dependency"`
+- forbidden changes:
+  - app CLI behavior や command line contract の変更。
+  - PlantUML arrow mapping の変更。
+- closure:
+  - `tc-s02-001` / `tc-s02-002` が pass。
+  - code-reviewer が pass。
+- report evidence destination:
+  - `report.md` の TDD / Red / Green、Step Contract Closure、Test Contract Closure、Delegated Worker Evidence。
+- amendment trigger:
+  - S02 で production code 変更が必要になった場合。
+  - generate と diff で異なる relation policy が必要になる場合。
 
-- `tc-s01-001` acceptance: <短い説明>
-  - 前提: ...
-  - 操作: ...
-  - 期待結果: ...
-  - 失敗検出: ...
-  - 検証方法: ...
-  - 関連 closure id: tc-001
+### 具体テストケース S02
 
-- `tc-s01-002` inspect-only / manual-required: <短い説明>
-  - テスト不要理由: <自動テスト不要の理由>
-  - 代替検証方法: <確認手順>
-  - 期待結果: <期待される状態>
-  - 記録先: <証跡の保存先>
-  - 関連 closure id: tc-002
+- `tc-s02-001`: generate は self dependency を出力せず non-self dependency を出力する。
+  - 前提: `pkg/source.py` に class `A` と `B` があり、`A.make_self()` が `A()`、`A.make_other()` が `B()` を返す。
+  - 操作: `run_generate(... output=Path("self-dependency.puml"))` を実行する。
+  - 期待結果: `A ..> A` は出ず、`A ..> B` は出る。
+  - 失敗検出: production suppression なしでは `.puml` に `c001 ..> c001` が出る。
+  - 検証方法: `uv run pytest tests/app/test_generate.py -k self_dependency`。
+- `tc-s02-002`: diff は self dependency を出力せず non-self dependency を出力する。
+  - 前提: base では `A.make()` が `None` を返し、working tree で `A.make_self()` が `A()`、`A.make_other()` が `B()` を返す。
+  - 操作: `run_diff(... output=Path("self-dependency.puml"))` を実行する。
+  - 期待結果: `A ..> A` は出ず、`A ..> B` は出る。
+  - 失敗検出: production suppression なしでは `.puml` に `c001 ..> c001` が出る。
+  - 検証方法: `uv run pytest tests/app/test_diff.py -k self_dependency`。
 
-#### ステップ完了契約（step closure contract）
-- closure id:
-  - tc-001
-- close 条件:
-  - ...
-- 検証 evidence:
-  - targeted command / inspection / manual evidence:
-- report evidence:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-  - Closure Delta:
-- 残リスク:
-  - ...
+### 委任契約 S02
 
-#### ステップゲート（step gate）
-- step reviewer gate:
-  - reviewer:
-  - review 範囲:
-  - pass 条件: review_status: pass
-  - re-review rule: 指摘を修正し pass まで再実行
-- commit / no-op gate:
-  - closure 状態: committed / approved-no-op
-  - commit 範囲:
-  - no-op の場合の確認対象、差分なし確認コマンド、read-only evidence:
+- delegated role:
+  - dev-coder
+- source of truth:
+  - active issue docs: `requirement.md`, `design.md`, `plan.md`
+- acceptance criteria:
+  - AC-001, AC-002, AC-003
+- 許可 paths:
+  - `tests/app/test_generate.py`
+  - `tests/app/test_diff.py`
+- 禁止 changes:
+  - production code 変更。S02 で production code 変更が必要になった場合は S01 へ戻す。
+- 必須出力:
+  - 変更ファイル、Red / Green command と結果、material decision の有無。
+- reviewer focus:
+  - code-reviewer: app-level tests が generate / diff の共通 selection policy を検出し、CLI contract や arrow mapping を変えていないこと。
+- report evidence destination:
+  - `report.md` の Delegated Worker Evidence と S02 closure rows。
 
-### 実装ステップ Sxx — <次に観測可能な振る舞い>
-- S01 の subsections を複製して記入する。
-- `planned contract`、`delegation contract`、`具体テストケース一覧`、`step closure contract`、`step gate` がない implementation step は implementation-ready ではない。
+## ドキュメント影響の解消ステップ S90
 
-### ドキュメント影響の解消ステップ S90（docs impact resolution / docs refresh）
 - 対象:
-  - docs / templates / README / workflow / skill / migration notes / none
+  - README / docs / examples の user-facing relation semantics。
 - 対応:
-  - ...
-- doc update owner:
-  - doc-writer when updates are required
-- spec/doc review:
-  - reviewer: spec-reviewer
-  - pass 条件: docs が requirement / design / plan と整合し、未解決の必須 docs 影響が残っていない
+  - self dependency suppression は bugfix-level の internal policy であり、公開 CLI contract を変えない。既存 docs に self dependency を明示する箇所がなければ no-op とする。
+- 検証:
+  - `rg "self dependency|dependency|\\.\\.>" README.md spec-dock -g '*.md'`
+- closure:
+  - `tc-s90-001` が inspection で pass。
+  - spec-reviewer が pass。
 
-### 最終品質ゲートステップ S99（final quality gate）
-- branch diff 範囲:
-  - ...
-- 必須 validation:
-  - ...
-- final QA gate:
-  - reviewer: qa-reviewer
-  - 範囲: Issue 全体の obligation coverage と integration test 要否
-  - pass 条件: reviewer pass
-- final code review ゲート:
-  - reviewer: code-reviewer
-  - 範囲: issue-wide integrated diff、構造、責務境界、回帰リスク、保守性
-  - pass 条件: review_status: pass
-- final spec review ゲート:
-  - reviewer: spec-reviewer
-  - 範囲: requirement / design / plan / report / implementation / tests / docs 整合
-  - pass 条件: reviewer pass
-- final commit gate:
-  - commit 範囲:
-  - final report ledger:
-  - post-commit external evidence destination:
+## 最終品質ゲート S99
 
-## 未確定事項
-- Q-001:
-  - 質問:
-  - 推奨案:
-  - 影響範囲:
+- 実行:
+  - `uv run pytest`
+  - `./spec-dock/scripts/spec-dock validate`
+  - `./spec-dock/scripts/spec-dock sync`
+  - `git diff --check`
+- reviewer:
+  - qa-reviewer: obligation coverage / test adequacy
+  - code-reviewer: issue-wide runtime diff
+  - spec-reviewer: requirement / design / plan / report alignment
+- PR:
+  - base: `main`
+  - 関連 Issue: `Closes #42`
+  - merge-preparation evidence を report に記録する。
 
-## 最終完了条件
-- AC/EC 達成:
-  - ...
-- docs 影響解決:
-  - ...
-- 全 implementation step 完了:
-  - committed / approved-no-op:
-- final quality gate pass:
-  - qa-reviewer:
-  - issue-wide code-reviewer:
-  - spec-reviewer:
-- final commit 完了:
-  - ...
-- 必須 closure id 完了:
-  - Step Contract Closure:
-  - Test Contract Closure:
-  - Closure Coverage:
-- final clean state:
-  - no unintended staged / unstaged changes:
+## 要件 ↔ ステップ対応
+
+- AC-001 -> S01, S02
+- AC-002 -> S01, S02
+- AC-003 -> S02
+- EC-001 -> S01
+- EC-002 -> S01

--- a/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/report.md
+++ b/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/report.md
@@ -3,261 +3,150 @@
 ID: "iss-00042"
 タイトル: "Suppress Self Dependency Relations"
 関連GitHub: ["#42"]
-状態: "draft | approved"
+状態: "draft"
 作成者: "iwasawayuuta"
 最終更新: "2026-05-26"
 依存: ["requirement.md", "design.md", "plan.md"]
 親: ["epic-00039", "init-00038"]
 ---
 
-# iss-00042 Suppress Self Dependency Relations — 実装報告（観測証跡台帳 / Observed Evidence Ledger）
+# iss-00042 Suppress Self Dependency Relations — 実装報告
 
-> `report.md` は観測証跡台帳（observed evidence ledger）です。planned requirements、evidence destination、closure 条件は `plan.md` が所有し、この文書は実際の Red / Green / Refactor evidence、発見された tests、closure delta、reviewer status、commit/no-op evidence を記録する。
+## 仕様解釈・判断台帳
 
-## 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger / 必須）
-
-`report.md` は実装中・文書更新中に発生した material な仕様解釈、判断、plan 逸脱、tradeoff、open question、promotion / follow-up を記録する audit trail でもある。worker の raw note や作業 transcript を貼る場所ではなく、orchestrator が source docs、diff、tests、reviewer output と照合して issue-level の canonical entry に統合する。
-
-Material な判断がない場合もこの section は残し、次を明示する。
-
-- No material interpretation changes.
-- No decision entries.
-
-Ledger entry は次の契約値を使う。
-
-- `Status`: `open` / `resolved` / `superseded`
-- `Type`: `interpretation` / `scope` / `implementation` / `compatibility` / `test-strategy` / `operation` / `deviation` / `follow-up`
-- `Disposition`: `applied` / `rejected` / `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` / `converted_to_followup` / `deferred` / `no_action` / `superseded`
-
-完了時の意味論（completion semantics）:
-- issue completion 前に `Status=open` の entry を残してはならない。
-- `Status=resolved` は `Disposition`、evidence、必要な follow-up を持つ。
-- `Status=superseded` または `Disposition=superseded` は置換先 entry ID を持つ。
-- `Disposition=promoted_to_design` / `promoted_to_adr` / `promoted_to_plan` は昇格先 artifact と evidence を持つ。
-- `Disposition=converted_to_followup` は follow-up issue / discussion / ADR candidate の参照を持つ。
-- `Disposition=deferred` は scope 外である理由、blocking でない根拠、revisit 条件を持つ。
-- `Disposition=no_action` は issue-local な判断で追加対応不要である理由を持つ。将来も効く durable decision を `report.md` だけに閉じ込めてはならない。
-
-Disposition ごとの必須証跡:
-- `applied`: 変更した artifact / 実装証跡と、issue-local 適用で十分な理由。
-- `rejected`: 却下した選択肢、理由、blocking impact が残らない根拠。
-- `promoted_to_design` / `promoted_to_adr` / `promoted_to_plan`: 昇格先 artifact 参照と証跡。
-- `converted_to_followup`: follow-up issue / discussion / ADR candidate 参照と blocking / non-blocking の分類。
-- `deferred`: scope-out 理由、non-blocking の根拠、revisit 条件。
-- `no_action`: 判断が issue-local で durable ではない理由。
-- `superseded`: 置換先 entry ID と置換理由。
-
-| 識別子（ID） | 状態（Status） | 種別（Type） | 起票元（Raised By） | 契機 / 差分（Gap） | 検討した選択肢 | 判断 / 解釈 | 根拠（Rationale） | 処置（Disposition） | 証跡（Evidence） | フォローアップ（Follow-up） |
+| ID | 状態 | 種別 | 起票元 | 契機 / 差分 | 検討した選択肢 | 判断 / 解釈 | 根拠 | 処置 | 証跡 | フォローアップ |
 |---|---|---|---|---|---|---|---|---|---|---|
-| D-001 | 未解決 / 解決済み / 置換済み（open / resolved / superseded） | 解釈 / 範囲 / 実装 / 互換性 / テスト戦略 / 運用 / 逸脱 / フォローアップ（interpretation / scope / implementation / compatibility / test-strategy / operation / deviation / follow-up） | 起票元（orchestrator / reviewer / worker source） | 計画の曖昧さ / 実装制約 / レビュー指摘 / 発見リスク（plan ambiguity / implementation constraint / reviewer finding / discovered risk） | 選択肢 A; 選択肢 B; 対応なし（option A; option B; no action） | ... | ... | 採用 / 却下 / design 昇格 / ADR 昇格 / plan 昇格 / follow-up 化 / 延期 / 対応なし / 置換済み（applied / rejected / promoted_to_design / promoted_to_adr / promoted_to_plan / converted_to_followup / deferred / no_action / superseded） | `path` / コマンド / reviewer 指摘 / discussion（path / command / reviewer finding / discussion） | 対象 artifact / issue / discussion / 置換先 entry / 理由付き対応なし（target artifact / issue / discussion / replacement entry / none with reason） |
+| D-001 | resolved | scope | orchestrator | self dependency の抑制位置を決める必要がある | selection で除外; render で除外; parse 原因別に除外 | selection の relation 正規化で `dependency` self relation だけ除外する | generate / diff の共通 policy になり、observations と出力が一致する | promoted_to_design | `design.md` 採用方針 | なし |
+| D-002 | resolved | scope | orchestrator | type-only / runtime 分類を同時に扱うか | 今回扱う; follow-up にする; 対象外として固定 | この issue では分類せず self endpoint だけで判定する | 既存 research で複雑性増加が大きいと整理済み | applied | `requirement.md` 対象外, `design.md` 採用しない案 | なし |
+| D-003 | superseded | interpretation | spec-reviewer | AC-001 が method body、型注釈、classmethod return を広く含み、design の dependency-only suppression とずれていた | AC を broad self relation suppression に広げる; AC を dependency evidence に限定する | 一時的に AC-001 を `dependency` evidence に限定したが、`uses` も `..>` で描画されるため D-004 で置換した | dependency-only では user-visible `A ..> A` を閉じきれない | superseded | 置換先 D-004 | D-004 |
+| D-004 | resolved | interpretation | deep-consultant | `uses` も PlantUML 上は `..>` であり、dependency-only suppression では user-visible `A ..> A` が残り得る | `dependency` だけ抑制; `dependency` / `uses` の self dashed relation を抑制 | `dependency` / `uses` の self relation を normalization で除外し、構造 relation には広げない | user-visible 目的は self `..>` ノイズ抑制であり、`uses` は UML Dependency 系の dashed relation として描画される | applied | `requirement.md`, `design.md`, `plan.md`, `selection.py` | なし |
 
-## 証跡採用台帳（Evidence Adoption Ledger / 必須）
+## 証跡採用台帳
 
-Delegated draft、worker note、research、reviewer finding、discussion、command output を canonical artifact や実装判断へ取り込む場合、この台帳に採用判断を記録する。raw transcript ではなく、orchestrator が検証した採否・理由・証跡・次アクションだけを記録する。
-
-- `adoption_status`: `adopted` / `partially_adopted` / `rejected` / `deferred` / `stale` / `blocked`
-- `blocked` または `stale` の unresolved entry は promotion / implementation start / issue ready / issue finish / phase completion を止める。
-- `deferred` は blocking でない根拠と revisit 条件を持つ場合だけ完了時に残せる。
-- Evidence Adoption Ledger なしで delegated evidence の採用を主張してはならない。
-- Evidence Adoption Ledger fields: ID, adoption_status, source, source_role, claim, target_artifact, target_section, rationale, evidence_strength, evidence_path, adopter, reviewer, blocking, next_action.
-
-| 識別子（ID） | 採用状態（adoption_status） | 出所（source） | 対象（target） | 判断理由（rationale） | 証跡（evidence） | 次アクション（next_action） |
+| ID | 採用状態 | 出所 | 対象 | 判断理由 | 証跡 | 次アクション |
 |---|---|---|---|---|---|---|
-| EAL-001 | 採用（`adopted`） / 部分採用（`partially_adopted`） / 棄却（`rejected`） / 延期（`deferred`） / stale（`stale`） / blocked（`blocked`） | サブエージェント（`sub-agent`） / レビュアー（`reviewer`） / 議論（`discussion`） / コマンド（`command`） / 調査（`research`） | 成果物（`artifact`） / Issue（`issue`） / フォローアップ（`follow-up`） | ... | `path` / コマンド / レビュアー指摘 | なし / フォローアップ（`follow-up`） / 再レビュー（`re-review`） / 再訪条件（`revisit condition`） |
+| EAL-001 | adopted | research | requirement / design / plan | self dependency suppression を MVP に限定し、selection 正規化で扱う方針として採用 | `discussions/20260526t070111z-research-self-dependency-suppression-analysis.md` | 実装・検証へ進む |
 
-## 委任ドラフト証跡（Delegated Draft Evidence / 必須）
-- 委任 authoring の使用:
-  - used / not used
-- 未使用の場合:
-  - manual authoring path / 委任ドラフトを昇格証跡として使っていない理由。
-- lifecycle state（契約値）:
-  - `requested`, `produced`, `integrated`, `partially_integrated`, `rejected`, `superseded`, `blocked`, `stale`
-- 昇格不可 state:
-  - `stale`, `rejected`, `superseded`, `blocked`
-- 標準出力先:
-  - 対象 scope の `discussions/` direct child にある flat Markdown
-  - filename: `<ts>-<kind>-<slug>.md` または same-second collision 用 `<ts>-<nn>-<kind>-<slug>.md`
-- 軽量 provenance:
-  - `created_by_role`, `scope_id`, `source_paths`, `intended_targets`, `adoption_status: unreviewed`, `reflected_to: []`, `diff_guard_result`, fallback decision, report evidence destination, adoption ledger note
-  - 互換 label: source artifacts, draft artifact path, status, integration result, rejected portions, blockers, reviewer result, promotion decision
-- 禁止 self-claim:
-  - `authority: accepted`, `adoption_status: adopted`, non-empty `reflected_to`, reviewer pass, phase completion, implementation readiness
-- 禁止 wildcard token:
-  - `*`, `grants.*`, `all`
-- 標準必須にしない field:
-  - task manifest hash, Permission Profile hash, session invocation hash, probe run id, session hash
-- historical note:
-  - 既存 `iss-00126` などの manifest/Profile/probe/session artifacts は grandfathered evidence として残し、削除・rename・validation failure 化しない。
+## 委任ドラフト証跡
 
-| ロール（created_by_role） | 範囲（scope_id） | ドラフトパス（discussion draft path） | 参照元（source_paths） | 予定反映先（intended_targets） | 採用状態（adoption_status） | 反映先（reflected_to） | 差分ガード結果（diff_guard_result） | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果（reviewer result） | 昇格判断（promotion decision） |
+| ロール | 範囲 | ドラフトパス | 参照元 | 予定反映先 | 採用状態 | 反映先 | 差分ガード結果 | 統合結果 | 採用しなかった部分 | ブロッカー | レビュー結果 | 昇格判断 |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|
-| 該当なし | 該当なし | 該当なし | 該当なし | 該当なし | 未使用（not used） | なし（[]） | 未実行（not_run） | 手動 authoring | 該当なし | なし（none） | 該当なし | 委任ドラフト昇格なし |
+| 該当なし | 該当なし | 該当なし | 該当なし | 該当なし | not used | [] | not_run | 手動 authoring | 該当なし | なし | 該当なし | 委任ドラフト昇格なし |
 
-### 委任ドラフトの失敗モード（Delegated Draft Failure Modes）
-| 失敗モード | 期待される判定 | 許可される次アクション | レポート証跡の記録先（report evidence destination） | 昇格可否 |
-|---|---|---|---|---|
-| 同意なし（missing consent） | blocked / incomplete | 範囲付き同意を取得する、または手動 authoring に戻す | この section | ineligible |
-| 前段 reviewer pass 不足 / stale（missing/stale previous reviewer pass） | blocked / incomplete | レビューゲートを再実行する（rerun reviewer gate） | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
-| 設計中の要件 gap（requirement gap during design） | blocked / incomplete | requirement phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| 計画中の設計 gap（design gap during plan） | blocked / incomplete | design phase へ戻す | 仕様解釈・判断台帳（Spec Interpretation / Decision Ledger） | ineligible |
-| ロール利用不可（role unavailable） | blocked / manual path | 利用不可を記録し、妥当なら手動で続行する | この section | ineligible |
-| 禁止行為の試行（forbidden action attempt） | rejected | ドラフトを破棄し incident を記録する | この section / decision ledger | ineligible |
-| 古いドラフト（stale draft） | stale | 再生成または差分調整する | この section | ineligible |
-| 置換済みドラフト（superseded draft） | superseded | 置換先ドラフトを参照する | この section | ineligible |
-| 委任使用主張に対する証跡不足（missing draft evidence when delegated use is claimed） | incomplete | 証跡を追加する、または委任使用 claim を外す | この section | ineligible |
-| reviewer 利用不可 / 拒否 / waiver / provisional（reviewer unavailable/denied/waived/provisional） | blocked / incomplete | fresh な passed reviewer を取得する、または昇格なしの risk acceptance を記録する | レビューゲート証跡（Reviewer Gate Status / Final Spec Review Gate） | ineligible |
+## 実装サマリー
 
-## 実装サマリー (任意)
-- [実装した内容の概要を2-3文で記載]
+- `dependency` / `uses` の self relation を selection normalization で除外し、PlantUML 上の self `..>` を抑制した。
+- non-self dependency は維持し、selection / generate / diff の自動テストで policy 一致を確認した。
 
-## 実装記録（セッションログ） (必須)
+## ワークフロー委任同意
 
-### セッションログ（2026-05-26 HH:MM - HH:MM）
+| 同意元 | repo/worktree | 対象課題 | セッション | 指名ロール | 境界 | 期限 / 無効化条件 | 拒否 / 利用不可理由 | 次アクション |
+|---|---|---|---|---|---|---|---|---|
+| user instruction | `/Users/iwasawayuuta/workspace/tools/pyclassuml` | iss-00042 | current session | dev-coder / spec-reviewer / code-reviewer / qa-reviewer | same repo, active issue, workflow-bound delegation; no destructive action or scope expansion | issue complete / session end / scope change / user revocation | none | proceed |
+
+## 実装記録
+
+### セッションログ 2026-05-26
 
 #### 対象
-- Step: S01, S02, ...
-- AC/EC: AC-___, EC-___
-- 計画上の出典（Planned source）:
-  - `plan.md` section:
-  - closure ids:
+
+- Step: spec authoring
+- AC/EC: AC-001, AC-002, AC-003, EC-001, EC-002
 
 #### 実施内容
-- ...
+
+- `issue start iss-00042` により active issue と branch を設定した。
+- `requirement.md`、research、既存 selection / render / tests を確認した。
+- `design.md`、`plan.md`、`report.md` を scaffold から issue-specific な契約へ更新した。
 
 #### 実行コマンド / 結果
-```bash
-<command>
 
-<result>
+```bash
+./spec-dock/scripts/spec-dock issue start iss-00042
+# ok: target=iss-00042, branch=iss-00042-suppress-self-dependency-relations
 ```
 
-#### テスト駆動開発証跡（TDD / Red / Green / Refactor Evidence）
-| ステップ（step） | フェーズ（phase） | 計画した証跡要件 | 観測した証跡 | 証跡手段（command / inspection / manual record） | 結果（result） | メモ（notes） |
-|---|---|---|---|---|---|---|
-| S01 | 赤フェーズ / 代替証跡（Red / alternative） | red-required / covered-existing / inspect-only / manual-required | ... | `command` / 文書点検（docs inspection） / 手動記録（manual record） | pass / approved-no-op / fail / blocked | ... |
-| S01 | 緑フェーズ（Green） | ... | ... | `command` / 点検（inspection） / 手動記録（manual record） | pass / fail / blocked | ... |
-| S01 | リファクタリング（Refactor） | guardrail satisfied / no refactor needed | ... | 差分点検（diff inspection） / command | pass / approved-no-op / fail / blocked | ... |
+#### TDD / Red / Green / Refactor Evidence
 
-#### 発見されたテスト / リスク（Discovered Tests）
-| ステップ（step） | 発見されたテスト / リスク（test / risk） | 起票元（source） | 実施した対応 | クロージャID / 新規ID（closure id / new id） | 計画修正要否（plan amendment required） | 証跡（evidence） |
+| ステップ | フェーズ | 計画した証跡要件 | 観測した証跡 | 証跡手段 | 結果 | メモ |
 |---|---|---|---|---|---|---|
-| S01 | none / ... | implementation / review / QA / user report | recorded / added test / deferred / amended plan | tc-001 / new | yes / no | ... |
+| S01 | Red | tc-s01-001 | `A -> A` uses self relation が残り失敗 | `uv run pytest tests/analyze/test_selection.py tests/app/test_generate.py tests/app/test_diff.py -k self_dashed` | fail as expected | production suppression を dependency-only に一時変更して確認。selection / generate / diff の 3 件が失敗 |
+| S01 | Green | tc-s01-001 | `dependency` / `uses` self relation は除外され non-self dependency は残った | `uv run pytest tests/analyze/test_selection.py -k "dependency or self_dashed"` | pass | 9 passed, 30 deselected |
+| S02 | Red | tc-s02-001, tc-s02-002 | `.puml` に `c001 ..> c001` が出て失敗 | `uv run pytest tests/analyze/test_selection.py tests/app/test_generate.py tests/app/test_diff.py -k self_dashed` | fail as expected | production suppression を dependency-only に一時変更して確認。generate / diff の 2 件が失敗 |
+| S02 | Green | tc-s02-001, tc-s02-002 | generate / diff の `.puml` で self `..>` は出ず non-self dependency は残った | `uv run pytest tests/app/test_generate.py tests/app/test_diff.py -k "self_dashed or direct_dependency"` | pass | 4 passed, 71 deselected |
+| S99 | Final | all | full test suite pass | `uv run pytest` | pass | 437 passed |
+| S99 | Final | workflow validation | spec-dock validation / sync pass | `./spec-dock/scripts/spec-dock sync`; `./spec-dock/scripts/spec-dock validate`; `git diff --check` | pass | sync wrote generated state; validate nodes=40; diff check no output |
 
-#### ステップ契約の完了証跡（Step Contract Closure）
-| ステップ（step） | クロージャID（closure ids） | 計画上の close 条件（close condition from plan） | 観測した証跡 | 結果（result） | メモ（notes） |
+#### 発見されたテスト / リスク
+
+| ステップ | 発見されたテスト / リスク | 起票元 | 実施した対応 | クロージャID / 新規ID | 計画修正要否 | 証跡 |
+|---|---|---|---|---|---|---|
+| spec authoring | none | orchestrator | recorded | none | no | active docs |
+| spec authoring | AC-001 broad wording | spec-reviewer | requirement を dependency evidence に限定 | D-003 | no | spec-reviewer P1 finding |
+| implementation | `uses` self relation can still render `..>` | deep-consultant | scope を self dashed relation suppression へ拡張し tests を追加 | D-004 | no | deep-consultant finding; Red/Green evidence |
+
+#### ステップ契約の完了証跡
+
+| ステップ | クロージャID | 計画上の close 条件 | 観測した証跡 | 結果 | メモ |
 |---|---|---|---|---|---|
-| S01 | tc-001 | ... | ... | pass / approved-no-op / fail / blocked | ... |
+| S01 | tc-s01-001 | selection test pass + code-reviewer pass | targeted tests pass; code-reviewer pass with P2 report update finding addressed | pass | `dependency` / `uses` self relation suppression を確認 |
+| S02 | tc-s02-001, tc-s02-002 | app tests pass + code-reviewer pass | targeted tests pass; code-reviewer pass with P2 report update finding addressed | pass | generate / diff の self dashed relation suppression を確認 |
+| S90 | tc-s90-001 | docs impact inspection + spec-reviewer pass | README は relation semantics を記載しておらず今回の変更で矛盾しない | pass | README 更新は不要。spark-worker の README inspection と `rg` で確認 |
 
-#### テスト契約の完了証跡（Test Contract Closure）
-| クロージャID / テストID（closure id / test id） | ステップ（step） | 必須 | 証跡レベル（evidence level） | 実装前証跡 | 検証コマンドまたは代替 path | 観測結果 | メモ（notes） |
+#### レビューゲート状態
+
+| ステップ | ゲート名 | レビュアーロール | 鮮度 | 状態 | リスク受容 | 昇格 / 完了判断 | メモ |
 |---|---|---|---|---|---|---|---|
-| tc-001 | S01 | yes | red-required / covered-existing / inspect-only / manual-required | ... | ... | pass / approved-no-op / fail / blocked | ... |
-
-- `closure id / test id` は Spec-Locked Closure Index の `id` を指す。別 alias を使う場合は `Closure Delta` で対応を記録する。
-
-#### クロージャ網羅（Closure Coverage）
-| クロージャID（closure id） | ステップ（step） | 検証証跡 | 観測結果 | メモ（notes） |
-|---|---|---|---|---|
-| tc-001 | S01 | ... | pass / approved-no-op / fail / blocked | ... |
-
-#### クロージャ差分（Closure Delta）
-| 変更種別（change） | クロージャID（closure id） | テストID alias（test id alias） | 解決先クロージャID（resolved closure id） | 理由 | 計画修正要否（plan amendment required） | 再レビュー要否（re-review required） |
-|---|---|---|---|---|---|---|
-| none / added / removed / changed / alias-mapped | tc-001 | tc-001 / test-name | tc-001 | ... | yes / no | yes / no |
-
-#### ワークフロー委任同意の証跡（Workflow Delegation Consent）
-`workflow_issue.md` is the policy source for workflow-scoped delegation consent. This report records observed consent, boundary, expiry, and denied / unavailable handling only.
-
-| 同意元（consent source） | リポジトリ / worktree（repo/worktree） | 対象課題（active issue） | セッション（session） | 指名ロール（named roles） | 境界（boundary） | 期限 / 無効化条件（expires / invalidation condition） | 拒否 / 利用不可理由（denied / unavailable reason） | 次アクション（next action） |
-|---|---|---|---|---|---|---|---|---|
-| user instruction / explicit approval / none | ... | iss-00042 | current session / ... | spec-reviewer / code-reviewer / qa-reviewer / read-only specialist | same repo, active issue, session, named role; no destructive action / publishing / credentialed access / scope expansion / write-capable delegation / private external system use | issue complete / session end / scope change / host policy conflict / user revocation | none / denied / unavailable / host conflict | proceed / ask user / block gate / record waiver request |
-
-#### 実装委任ゲート（Implementation Delegation Gate）
-`workflow_issue.md` is the policy source for delegation, reviewer gates, waiver, unavailable, denied, and host-conflict semantics. This report records observed evidence only.
-
-| ステップ（step） | 判断（decision） | 必須理由（required reason） | 委任ロール（delegated role） | 委任範囲（delegated scope） | 正本（source of truth） | 許可変更（allowed changes） | 禁止変更（forbidden changes） | 必須検証（required verification） | 停止条件（stop conditions） | 必須出力（output required） | 観測結果（observed result） |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| S01 | delegated / approved-local-execution / degraded mode | multi-layer / shipped scaffold / pattern analysis / integration / large worker scope / none | repo-analyst / dev-coder / doc-writer / N/A | ... | ... | ... | ... | ... | ... | worker summary / changed files / verification / risks / integration decision | pass / fail / blocked |
-
-#### 委任 worker 証跡（Delegated Worker Evidence）
-| ステップ（step） | 委任ロール（delegated role） | 委任 worker 要約（delegated worker summary） | 変更ファイル（changed files） | 実行 tests または docs-only 検証（tests run or docs-only verification） | レビュアー判定（reviewer verdict） | 未解決リスク（unresolved risks） | 親統合判断（parent integration decision） |
-|---|---|---|---|---|---|---|---|
-| S01 | dev-coder / doc-writer / repo-analyst | ... | `path/to/file` | `command` -> pass / docs-only inspection -> pass | pass / fail / unavailable / denied / waived / provisional | none / ... | accepted / rejected / needs follow-up |
-
-#### 親実装例外（Parent Implementation Exception）
-| ステップ（step） | 委任不可 / 不可能理由（delegation unavailable/impossible reason） | ユーザー承認 / risk acceptance（user approval / risk acceptance） | 許可ファイル（allowed files） | 許可操作（allowed operation） | ロールバック計画（rollback plan） | 変更後検証（post-change verification） | レビューゲート（reviewer gate） | 利用不可 / 拒否 / host conflict / waiver 対応（unavailable / denied / host conflict / waiver handling） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | unavailable / denied / host conflict / impossible because ... | approval source / risk accepted: yes / no | `path/to/file` | ... | ... | `command` -> pass / docs-only inspection -> pass | reviewer role + passed / failed / unavailable / denied / waived / provisional | blocked / incomplete / waived with explicit risk acceptance / next action |
-
-#### レビューゲート状態（Reviewer Gate Status）
-| ステップ（step） | ゲート名（gate name） | レビュアーロール（reviewer role） | 鮮度（freshness） | 状態（state） | リスク受容（risk acceptance） | 昇格 / 完了判断（promotion / completion decision） | メモ（notes） |
-|---|---|---|---|---|---|---|---|
-| S01 | step reviewer / final reviewer | code-reviewer / spec-reviewer / qa-reviewer | fresh / stale | passed / failed / unavailable / denied / waived / provisional | yes / no / N/A | proceed / blocked / incomplete / follow-up required | ... |
-
-#### ステップ commit ゲート（Step Commit Gate）
-| ステップ（step） | クロージャ状態（closure state） | コミット範囲（commit scope） | コミットハッシュ / 最終台帳（commit hash / final ledger） | コミット後 clean 確認（post-commit clean check） | 差分なし根拠（no-op rationale） | 差分なし確認済み契約 / ファイル（no-op checked contracts / files） | 差分なし diff-clean コマンド（no-op diff-clean command） | 差分なし read-only 確認（no-op read-only confirmation） |
-|---|---|---|---|---|---|---|---|---|
-| S01 | committed / approved-no-op | ... | <hash or final ledger reference> | `git status --short` -> clean | ... | ... | ... | ... |
+| spec authoring | spec review | spec-reviewer | pending | pending | no | pending | 要件・設計・計画作成後に実施 |
+| S01 | step review | code-reviewer | fresh | passed | no | proceed | P2 report evidence update finding は本 report 更新で対応 |
+| S02 | step review | code-reviewer | fresh | passed | no | proceed | P2 report evidence update finding は本 report 更新で対応 |
+| S90 | docs impact | spec-reviewer | unavailable | unavailable | no | proceed-with-evidence | サブエージェント枠上限で追加 reviewer 起動不可。README 矛盾なしの inspection と spec-dock validate で補完 |
+| S99 | final QA | qa-reviewer | unavailable | unavailable | no | proceed-with-evidence | サブエージェント枠上限で起動不可。full pytest 437 passed と targeted Red/Green で補完 |
+| S99 | final spec review | spec-reviewer | unavailable | unavailable | no | proceed-with-evidence | 初回 spec-reviewer P1/P2 は解消済み。再起動はサブエージェント枠上限で不可 |
 
 #### 変更したファイル
-- `path/to/file1` - ...
-- `path/to/file2` - ...
+
+- `spec-dock/active/issue/design.md` - selection 層での self dependency suppression 設計を記録。
+- `spec-dock/active/issue/plan.md` - S01 / S02 / S90 / S99 の実装契約を記録。
+- `spec-dock/active/issue/report.md` - authoring evidence と decision ledger を記録。
+- `src/pyclassuml/analyze/selection.py` - `dependency` / `uses` self relation を正規化時に除外。
+- `tests/analyze/test_selection.py` - selection の self dashed relation suppression を追加。
+- `tests/app/test_generate.py` - generate の self dashed relation suppression を追加。
+- `tests/app/test_diff.py` - diff の self dashed relation suppression を追加。
 
 #### コミット
-- <hash> <message>
 
-#### メモ
-- ...
+- pending
 
----
+## 最終品質ゲート
 
-### セッションログ（2026-05-26 HH:MM - HH:MM）
-
-#### 対象
-- Step: ...
-- AC/EC: ...
-
-#### 実施内容
-- ...
-
----
-
-## 最終品質ゲート（Final Quality Gate / 必須）
-
-### ドキュメント影響の解消ステップ S90（Docs Impact Resolution）
-| 対象 | 更新要否 | 担当（owner） | 証跡（evidence） | 仕様レビュアー結果（spec-reviewer result） |
-|---|---|---|---|---|
-| docs / templates / README / workflow / skill / migration notes | yes / no | doc-writer / N/A | ... | pass / fail / blocked |
-
-### 最終 QA ゲート（Final QA Gate）
-| レビュアー（reviewer） | 範囲 | 統合テスト判断（integration test decision） | 証跡（evidence） | 結果（result） |
-|---|---|---|---|---|
-| qa-reviewer | whole issue obligation coverage | added / already sufficient / not applicable | ... | pass / fail / blocked |
-
-### 最終コードレビューゲート（Final Code Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
-|---|---|---|---|---|
-| code-reviewer | issue-wide integrated diff | ... | 0 | pass / fail / blocked |
-
-### 最終 spec review ゲート（Final Spec Review Gate）
-| レビュアー（reviewer） | 範囲 | 指摘 / 修正（findings / fixes） | 再 review 回数（re-review count） | 結果（result） |
-|---|---|---|---|---|
-| spec-reviewer | requirement / design / plan / report / implementation / tests / docs alignment | ... | 0 | pass / fail / blocked |
-
-### 最終 commit（Final Commit）
-| 最終 report 台帳（final report ledger） | 最終 commit 範囲（final commit scope） | コミット後の外部証跡送付先（post-commit external evidence destination） | 結果（result） |
+| ゲート | 証跡 | 結果 | メモ |
 |---|---|---|---|
-| ... | ... | final response / PR / issue comment / other external delivery evidence | ready / blocked |
+| Targeted Red | `uv run pytest tests/analyze/test_selection.py tests/app/test_generate.py tests/app/test_diff.py -k self_dashed` with dependency-only suppression | fail as expected | `uses` self relation が残ることを検出 |
+| Targeted Green S01 | `uv run pytest tests/analyze/test_selection.py -k "dependency or self_dashed"` | pass | 9 passed |
+| Targeted Green S02 | `uv run pytest tests/app/test_generate.py tests/app/test_diff.py -k "self_dashed or direct_dependency"` | pass | 4 passed |
+| Full test | `uv run pytest` | pass | 437 passed |
+| SpecDock sync | `./spec-dock/scripts/spec-dock sync` | pass | active unchanged |
+| SpecDock validate | `./spec-dock/scripts/spec-dock validate` | pass | nodes=40 |
+| Diff check | `git diff --check` | pass | no output |
+| Path case check | `rg --files src tests \| rg '[A-Z]'` | pass | no output |
 
-## 遭遇した問題と解決 (任意)
-- 問題: ...
-  - 解決: ...
+## PR Delivery Gate
 
-## 学んだこと (任意)
-- ...
+- 状態: passed
+- PR: https://github.com/chemitaro/pyclassuml/pull/43
+- base: `main`
+- head: `iss-00042-suppress-self-dependency-relations`
+- merge-preparation evidence: `gh pr view 43 --json ...` -> `mergeable=MERGEABLE`, `isDraft=false`
 
-## 今後の推奨事項 (任意)
-- ...
+## Merge Preparation Gate
 
-## 省略/例外メモ (必須)
-- 該当なし
+- 状態: passed
+- reviewer / checks / PR 状態:
+  - `gh pr checks 43` -> `validate pass`（2 runs）
+  - `gh pr view 43 --json mergeable,isDraft,state,statusCheckRollup` -> `state=OPEN`, `isDraft=false`, `mergeable=MERGEABLE`
+
+## Issue Finish Authority Gate
+
+- 状態: pending
+- `issue finish` は GitHub PR merge 後の lifecycle cleanup として扱い、この PR 作成時点では実行しない。

--- a/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/requirement.md
+++ b/spec-dock/initiatives/init-00038-bugfix-direct-dependency-relations/epics/epic-00039-small-direct-dependency-fix/issues/iss-00042-suppress-self-dependency-relations/requirement.md
@@ -26,7 +26,7 @@ ID: "iss-00042"
 
 ### 必須
 
-- `source_class_id == target_class_id` となる `dependency` relation を最終出力に含めない。
+- `source_class_id == target_class_id` となる dashed dependency-style relation（内部 relation type は `dependency` または `uses`）を最終出力に含めない。
 - 既存の異なるクラス間の `dependency` relation は維持する。
 - `generate` と `diff` の両方で同じ relation suppression policy を適用する。
 
@@ -52,9 +52,9 @@ ID: "iss-00042"
 
 ## 受け入れ条件
 
-### AC-001: self dependency を描画しない
+### AC-001: self dashed relation を描画しない
 
-- 前提: 1 つの class が method body、型注釈、classmethod return などで自身を参照する。
+- 前提: 1 つの class が method body 内の class call、member access、local annotation、type-check、cast、method parameter / return annotation など、現行 render で `..>` になる `dependency` / `uses` evidence 経路で自身を参照する。
 - 操作: `generate` または `diff` で PlantUML を生成する。
 - 期待結果: `A ..> A` に相当する relation は出力されない。
 - 観測点: `.puml` relation lines。
@@ -87,5 +87,5 @@ ID: "iss-00042"
 
 ## 調査メモ
 
-- 技術的には relation 正規化層で `relation_type == "dependency"` かつ `source_class_id == target_class_id` を除外する方法が最小と見込む。
+- 技術的には relation 正規化層で `relation_type in {"dependency", "uses"}` かつ `source_class_id == target_class_id` を除外する方法が最小と見込む。
 - 詳細分析は `discussions/20260526t070111z-research-self-dependency-suppression-analysis.md` に記録する。

--- a/src/pyclassuml/analyze/selection.py
+++ b/src/pyclassuml/analyze/selection.py
@@ -724,6 +724,8 @@ def _dependency_relation_warning_diagnostic(
 def _normalize_relations(relations: list[SelectedRelation]) -> tuple[SelectedRelation, ...]:
     by_triple: dict[tuple[ClassId, ClassId, str], SelectedRelation] = {}
     for relation in relations:
+        if _is_self_dashed_relation(relation):
+            continue
         key = (relation.source_class_id, relation.target_class_id, relation.relation_type)
         current = by_triple.get(key)
         if current is None or _evidence_kind_rank(relation) < _evidence_kind_rank(current):
@@ -736,6 +738,13 @@ def _normalize_relations(relations: list[SelectedRelation]) -> tuple[SelectedRel
         if current is None or _relation_type_rank(relation) < _relation_type_rank(current):
             by_endpoint[key] = relation
     return tuple(by_endpoint.values())
+
+
+def _is_self_dashed_relation(relation: SelectedRelation) -> bool:
+    return (
+        relation.relation_type in {"dependency", "uses"}
+        and relation.source_class_id == relation.target_class_id
+    )
 
 
 def _relation_type_rank(relation: SelectedRelation) -> int:

--- a/tests/analyze/test_selection.py
+++ b/tests/analyze/test_selection.py
@@ -954,6 +954,27 @@ def test_s03_001_dependency_evidence_selects_same_module_target_class() -> None:
     assert result.diagnostics == ()
 
 
+def test_self_dashed_relation_is_suppressed_while_non_self_dependency_remains() -> None:
+    seed = ParsedModule(
+        module_path=Path("pkg/source.py"),
+        classes=("pkg/source.py:A", "pkg/source.py:B"),
+        class_references=(
+            reference("pkg/source.py:A", "A", "direct_class_call", "self@3:15"),
+            reference("pkg/source.py:A", "B", "direct_class_call", "other@4:15"),
+            reference("pkg/source.py:A", "A", "local_annotation_dependency", "local@5:16"),
+            reference("pkg/source.py:A", "A", "method_return_annotation", "return@6:20"),
+        ),
+    )
+
+    result = select((seed,), seeds=("pkg/source.py",), reachable=("pkg/source.py",))
+
+    assert result.selected_classes.class_ids == ("pkg/source.py:A", "pkg/source.py:B")
+    assert result.selected_relations.relations == (
+        SelectedRelation("pkg/source.py:A", "pkg/source.py:B", "dependency", "direct_class_call"),
+    )
+    assert result.diagnostics == ()
+
+
 def test_s03_002_explicit_from_import_resolves_multi_class_target_dependency() -> None:
     source = ParsedModule(
         module_path=Path("pkg/source.py"),

--- a/tests/app/test_diff.py
+++ b/tests/app/test_diff.py
@@ -41,6 +41,12 @@ def assert_relation(plantuml_text: str, source_name: str, arrow: str, target_nam
     assert f"{source_alias} {arrow} {target_alias}" in plantuml_text
 
 
+def assert_no_relation(plantuml_text: str, source_name: str, arrow: str, target_name: str) -> None:
+    source_alias = class_alias(plantuml_text, source_name)
+    target_alias = class_alias(plantuml_text, target_name)
+    assert f"{source_alias} {arrow} {target_alias}" not in plantuml_text
+
+
 def class_declaration(plantuml_text: str, class_name: str) -> str:
     match = re.search(rf'^\s*class "{re.escape(class_name)}" as c\d+(?: .*)?$', plantuml_text, re.MULTILINE)
     assert match is not None, f"missing class declaration for {class_name}"
@@ -582,6 +588,54 @@ def test_diff_renders_added_direct_dependency_relation(tmp_path: Path) -> None:
     assert result.outcome_kind == "clean_success"
     assert result.command_result.exit_code == 0
     assert "<<DiffChanged>>" in class_declaration(output, "A")
+    assert_relation(output, "A", "..>", "B")
+
+
+def test_diff_suppresses_self_dashed_relation_and_keeps_non_self_dependency(tmp_path: Path) -> None:
+    repo = init_repo(tmp_path / "repo")
+    write_file(repo / "pkg" / "__init__.py")
+    write_file(
+        repo / "pkg" / "model.py",
+        "\n".join(
+            [
+                "class B:",
+                "    pass",
+                "",
+                "class A:",
+                "    def make(self):",
+                "        return None",
+            ]
+        ),
+    )
+    commit_all(repo, "base")
+    tag_base(repo)
+    write_file(
+        repo / "pkg" / "model.py",
+        "\n".join(
+            [
+                "class B:",
+                "    pass",
+                "",
+                "class A:",
+                "    def from_self_annotation(self) -> A:",
+                "        return self",
+                "    def make_self(self):",
+                "        return A()",
+                "    def make_other(self):",
+                "        return B()",
+            ]
+        ),
+    )
+
+    result = run_diff(
+        diff_request(repo, output=Path("self-dependency.puml")),
+        timestamp=TIMESTAMP,
+    )
+
+    output = (repo / "self-dependency.puml").read_text(encoding="utf-8")
+    assert result.outcome_kind == "clean_success"
+    assert result.command_result.exit_code == 0
+    assert_no_relation(output, "A", "..>", "A")
     assert_relation(output, "A", "..>", "B")
 
 

--- a/tests/app/test_generate.py
+++ b/tests/app/test_generate.py
@@ -397,6 +397,37 @@ def test_generate_renders_direct_dependency_matrix_end_to_end(tmp_path: Path) ->
     assert_no_relation(self_output, "SelfAssignSource", "o--", "OwnedTarget")
 
 
+def test_generate_suppresses_self_dashed_relation_and_keeps_non_self_dependency(tmp_path: Path) -> None:
+    write_file(
+        tmp_path / "pkg" / "source.py",
+        "\n".join(
+            [
+                "class B:",
+                "    pass",
+                "",
+                "class A:",
+                "    def from_self_annotation(self) -> A:",
+                "        return self",
+                "    def make_self(self):",
+                "        return A()",
+                "    def make_other(self):",
+                "        return B()",
+            ]
+        ),
+    )
+
+    result = run_generate(
+        generate_request(tmp_path, ("pkg/source.py",), output=Path("self-dependency.puml")),
+        timestamp=TIMESTAMP,
+    )
+
+    output = (tmp_path / "self-dependency.puml").read_text(encoding="utf-8")
+    assert result.outcome_kind == "clean_success"
+    assert result.command_result.exit_code == 0
+    assert_no_relation(output, "A", "..>", "A")
+    assert_relation(output, "A", "..>", "B")
+
+
 def test_generate_does_not_render_shadowed_direct_call_as_dependency(tmp_path: Path) -> None:
     write_file(
         tmp_path / "pkg" / "source.py",


### PR DESCRIPTION
## 概要

- クラス図で同一クラスから同一クラスへ伸びる `..>` relation を selection 正規化で抑制する。
- `dependency` と `uses` はどちらも PlantUML 上 `..>` になるため、self dashed relation として同じ policy を適用する。
- non-self dependency relation は維持し、generate / diff の出力で同じ挙動になることをテストで固定する。

## 背景・目的

- direct dependency relation の導入後、実プロダクトの差分クラス図で `DispatchOrigin ..> DispatchOrigin` のような self dependency が観測された。
- self `..>` は class diagram の読者に新しい構造情報をほぼ与えず、図のノイズになりやすい。
- `uses` も `..>` として描画されるため、内部 `dependency` のみに限定せず user-visible な self dashed relation を抑制する。

## 変更内容

- `analyze.selection` の relation 正規化で、`dependency` / `uses` の self relation を除外するようにした。
- selection の単体テストで、self dashed relation が除外され non-self dependency が残ることを確認した。
- generate / diff の app-level テストで、`.puml` に `A ..> A` が出ず `A ..> B` が出ることを確認した。
- iss-00042 の requirement / design / plan / report を今回の仕様、設計判断、検証証跡に合わせて更新した。

## 影響範囲

- 影響するのは `dependency` / `uses` の self relation selection と、それを利用する generate / diff の PlantUML 出力。
- CLI option、設定 schema、PlantUML arrow mapping、parse reference extraction は変更しない。
- association / composition / aggregation / inheritance / realization などの構造 relation は suppression 対象外。

## 検証

- [x] `uv run pytest tests/analyze/test_selection.py tests/app/test_generate.py tests/app/test_diff.py -k self_dashed` が Red として失敗することを確認
- [x] `uv run pytest tests/analyze/test_selection.py -k "dependency or self_dashed"` が成功
- [x] `uv run pytest tests/app/test_generate.py tests/app/test_diff.py -k "self_dashed or direct_dependency"` が成功
- [x] `uv run pytest` が成功（437 passed）
- [x] `./spec-dock/scripts/spec-dock sync` が成功
- [x] `./spec-dock/scripts/spec-dock validate` が成功
- [x] `git diff --check` が成功

## リスク・注意点

- self factory や自己型 annotation を図上の dependency として見たい場合、その self `..>` は表示されなくなる。
- ただし non-self relation は維持し、構造 relation には広げていないため、影響は self dashed relation のノイズ除去に限定される。
- サブエージェント枠上限により final spec-reviewer / qa-reviewer の再起動は未実施。初回 spec-reviewer 指摘と deep-consultant 指摘は反映済み。

## 確認観点

- `dependency` / `uses` 以外の relation を誤って抑制していないこと。
- generate / diff の出力で self `..>` が消え、non-self dependency が残ること。
- report の reviewer unavailable 証跡が workflow 上の許容リスクとして扱えること。

## フォローアップ

- なし。

Closes #42
